### PR TITLE
Add support for template_id on meeting_create

### DIFF
--- a/lib/zoom/actions/meeting.rb
+++ b/lib/zoom/actions/meeting.rb
@@ -13,7 +13,7 @@ module Zoom
       # Create a meeting on Zoom, return the created meeting URL
       def meeting_create(*args)
         params = Zoom::Params.new(Utils.extract_options!(args))
-        params.require(:user_id).permit(%i[topic type start_time duration schedule_for timezone password agenda tracking_fields recurrence settings])
+        params.require(:user_id).permit(%i[topic type start_time duration schedule_for timezone password agenda tracking_fields recurrence settings template_id])
         Utils.process_datetime_params!(:start_time, params)
         Utils.parse_response self.class.post("/users/#{params[:user_id]}/meetings", body: params.except(:user_id).to_json, headers: request_headers)
       end

--- a/spec/lib/zoom/actions/meeting/create_spec.rb
+++ b/spec/lib/zoom/actions/meeting/create_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe Zoom::Actions::Meeting do
   let(:zc) { zoom_client }
-  let(:args) { { topic: 'Zoom Meeting Topic', start_time: '2020-05-05T21:00:00Z', timezone: 'America/New_York', duration: 30, type: 2, user_id: 'r55v2FgSTVmDmVot18DX3A' } }
+  let(:args) { { topic: 'Zoom Meeting Topic', start_time: '2020-05-05T21:00:00Z', timezone: 'America/New_York', duration: 30, type: 2, user_id: 'r55v2FgSTVmDmVot18DX3A', template_id: 'template_id' } }
   let(:response) { zc.meeting_create(args) }
 
   describe '#meeting_create action' do


### PR DESCRIPTION
The template_id option is used so we can create admin templates on zoom and use them for our meetings created through the API. This commit adds support for this option allowing the parameter.