### PR TITLE
Deprecate JWT Client

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    zoom_rb (1.1.7)
+    zoom_rb (1.1.8)
       httparty (>= 0.13)
       json (>= 1.8)
       jwt

--- a/lib/zoom/clients/jwt.rb
+++ b/lib/zoom/clients/jwt.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 require 'jwt'
+require 'logger'
 
 module Zoom
   class Client
     class JWT < Zoom::Client
 
       def initialize(config)
+        ::Logger.new(STDOUT).warn('Zoom::Client::JWT is deprecated. Please use Zoom::Client::ServerToServerOAuth instead. See: https://developers.zoom.us/docs/internal-apps/jwt-faq/')
         Zoom::Params.new(config).require(:api_key, :api_secret)
         config.each { |k, v| instance_variable_set("@#{k}", v) }
         self.class.default_timeout(@timeout || 20)

--- a/lib/zoom/version.rb
+++ b/lib/zoom/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Zoom
-  VERSION = '1.1.7'
+  VERSION = '1.1.8'
 end


### PR DESCRIPTION
This will likely be the final version in the 1.x releases. 2.x will remove the JWT client and use the S2SOAuth client as recommended in the zoom docs.