### PR TITLE
Add support for `include_fields` enum parameter

### DIFF
--- a/lib/zoom/actions/report.rb
+++ b/lib/zoom/actions/report.rb
@@ -11,10 +11,10 @@ module Zoom
       get 'meeting_details_report', '/report/meetings/:id'
 
       get 'meeting_participants_report', '/report/meetings/:id/participants',
-        permit: %i[page_size next_page_token]
+        permit: %i[page_size next_page_token include_fields]
 
       get 'webinar_participants_report', '/report/webinars/:id/participants',
-        permit: %i[page_size next_page_token]
+        permit: %i[page_size next_page_token include_fields]
 
       get 'webinar_details_report', '/report/webinars/:webinar_id'
     end


### PR DESCRIPTION
Both the GET `/report/meetings/{meetingId}/participants` and GET `/report/webinars/{webinarId}/participants` endpoints support the `include_fields` enum to specify loading the `registrant_id` for each participant, so this adds support for that to the gem.
