### PR TITLE
Add pre_schedule as an optional parameter to the meeting_create action

### DIFF
--- a/lib/zoom/actions/meeting.rb
+++ b/lib/zoom/actions/meeting.rb
@@ -13,7 +13,7 @@ module Zoom
       post 'meeting_create', '/users/:user_id/meetings',
         permit: %i[
           topic type start_time duration schedule_for timezone password default_password agenda tracking_fields
-          recurrence settings template_id
+          recurrence settings template_id pre_schedule
         ]
 
       # Get a meeting on Zoom via meeting ID, return the meeting info.


### PR DESCRIPTION
Per https://developers.zoom.us/docs/api/rest/reference/zoom-api/methods/#operation/meetingCreate one can add the `pre_schedule: true` parameter.

Currently we're using v1.1.8 of the app. Ideally we'd love to see this go into v1.1.9.

From the docs: 
> Whether to create a prescheduled meeting via the GSuite app. This only supports the meeting type value of 2 (scheduled meetings) and 3 (recurring meetings with no fixed time).
>
> true - Create a prescheduled meeting.
> false - Create a regular meeting.Default: false

Is there a reason this was omitted other than it's not commonly used?

Thanks!