### PR TITLE
Adds a meeting_delete_registrant action

### DIFF
--- a/lib/zoom/actions/meeting.rb
+++ b/lib/zoom/actions/meeting.rb
@@ -49,6 +49,9 @@ module Zoom
           language occurrence_ids auto_approve
         ]
 
+      # Delete a meeting registrant.
+      delete 'meeting_delete_registrant', '/meetings/:meeting_id/registrants/:registrant_id'
+
       # Register up to 30 registrants at once for a meeting that requires registration.
       post 'batch_registrants', '/meetings/:meeting_id/batch_registrants',
         permit: %i[registrants auto_approve registrants_confirmation_email]

--- a/spec/lib/zoom/actions/meeting/delete_registrant_spec.rb
+++ b/spec/lib/zoom/actions/meeting/delete_registrant_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Zoom::Actions::Meeting do
+  let(:zc) { zoom_client }
+  let(:args) { { meeting_id: 1, registrant_id: 'abcdef' } }
+
+  describe '#meeting_delete_registrant action' do
+    before :each do
+      stub_request(
+        :delete,
+        zoom_url("/meetings/#{args[:meeting_id]}/registrants/#{args[:registrant_id]}")
+      ).to_return(status: 204, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it "requires a 'meeting_id' and 'registrant_id' argument" do
+      expect {
+        zc.meeting_delete_registrant(filter_key(args, :meeting_id))
+      }.to raise_error(Zoom::ParameterMissing)
+      expect {
+        zc.meeting_delete_registrant(filter_key(args, :registrant_id))
+      }.to raise_error(Zoom::ParameterMissing)
+    end
+
+    it 'returns a status code of 204' do
+      expect(zc.meeting_delete_registrant(args)).to eq(204)
+    end
+  end
+end


### PR DESCRIPTION
Adds a meeting_delete_registrant action per the spec at https://developers.zoom.us/docs/api/rest/reference/zoom-api/methods/\#operation/meetingregistrantdelete.

We added this before realizing there was an open PR https://github.com/kyleboe/zoom_rb/pull/465 to do some similar work. We're happy either way.

