### PR TITLE
Action to fetch user's ZAK token

### DIFF
--- a/lib/zoom/actions/user.rb
+++ b/lib/zoom/actions/user.rb
@@ -69,6 +69,8 @@ module Zoom
 
       patch 'user_status_update', '/users/:id/status',
         permit: :status
+
+      get 'user_zak', '/users/me/zak'
     end
   end
 end

--- a/spec/fixtures/user/zak.json
+++ b/spec/fixtures/user/zak.json
@@ -1,0 +1,3 @@
+{
+  "token": "eyJ0eXAiOiJKV1QiLCJzdiI6IjAwMDAwMSIsInptX3NrbSI6InptX28ybSIsImFsZyI6IkhTMjU2In0.eyJhdWQiOiJjb"
+}

--- a/spec/lib/zoom/actions/user/zak_spec.rb
+++ b/spec/lib/zoom/actions/user/zak_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Zoom::Actions::User do
+  let(:zc) { zoom_client }
+
+  describe '#user_zak action' do
+    context 'with a valid response' do
+      before :each do
+        stub_request(
+          :get,
+          zoom_url("/users/me/zak")
+        ).to_return(status: 200,
+                    body: json_response('user', 'zak'),
+                    headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'returns a users zak token' do
+        res = zc.user_zak
+        expected_response = JSON.parse(json_response('user', 'zak'))
+        expect(res['token']).to eq(expected_response['token'])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds an action to fetch an user's ZAK token as per spec at https://developers.zoom.us/docs/api/rest/reference/user/methods/#operation/userZak
