### PR TITLE
Add waiting_room parameter to meeting_create

### DIFF
--- a/lib/zoom/actions/meeting.rb
+++ b/lib/zoom/actions/meeting.rb
@@ -13,7 +13,7 @@ module Zoom
       post 'meeting_create', '/users/:user_id/meetings',
         permit: %i[
           topic type start_time duration schedule_for timezone password default_password agenda tracking_fields
-          recurrence settings template_id pre_schedule
+          recurrence settings template_id pre_schedule waiting_room
         ]
 
       # Get a meeting on Zoom via meeting ID, return the meeting info.

--- a/spec/lib/zoom/actions/meeting/create_spec.rb
+++ b/spec/lib/zoom/actions/meeting/create_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe Zoom::Actions::Meeting do
   let(:zc) { zoom_client }
-  let(:args) { { topic: 'Zoom Meeting Topic', start_time: '2020-05-05T21:00:00Z', timezone: 'America/New_York', duration: 30, type: 2, user_id: 'r55v2FgSTVmDmVot18DX3A', template_id: 'template_id' } }
+  let(:args) { { topic: 'Zoom Meeting Topic', start_time: '2020-05-05T21:00:00Z', timezone: 'America/New_York', duration: 30, type: 2, user_id: 'r55v2FgSTVmDmVot18DX3A', template_id: 'template_id', waiting_room: false } }
   let(:response) { zc.meeting_create(args) }
 
   describe '#meeting_create action' do


### PR DESCRIPTION
Adds the waiting_room parameter (boolean) to meeting_create to enable the [Waiting Room feature](https://support.zoom.us/hc/en-us/articles/115000332726-Waiting-Room). 