### PR TITLE
Add a webinar_registrant_delete action

### DIFF
--- a/lib/zoom/actions/webinar.rb
+++ b/lib/zoom/actions/webinar.rb
@@ -66,6 +66,9 @@ module Zoom
           purchasing_time_frame role_in_purchase_process no_of_employees comments custom_questions
         ]
 
+      delete 'webinar_registrant_delete', '/webinars/:webinar_id/registrants/:registrant_id',
+        permit: :occurrence_id
+
       put 'webinar_registrants_status_update', '/webinars/:id/registrants/status',
         require: :action,
         permit: [ :occurrence_id, registrants: [] ]

--- a/spec/lib/zoom/actions/webinar/registrants/delete_spec.rb
+++ b/spec/lib/zoom/actions/webinar/registrants/delete_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Zoom::Actions::Webinar do
+  let(:zc) { zoom_client }
+  let(:args) { { webinar_id: 1, registrant_id: 'abcdef' } }
+
+  describe '#webinar_registrant_delete action' do
+    before :each do
+      stub_request(
+        :delete,
+        zoom_url("/webinars/#{args[:webinar_id]}/registrants/#{args[:registrant_id]}")
+      ).to_return(status: 204, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it "requires a 'webinar_id' and 'registrant_id' argument" do
+      expect {
+        zc.webinar_registrant_delete(filter_key(args, :webinar_id))
+      }.to raise_error(Zoom::ParameterMissing)
+      expect {
+        zc.webinar_registrant_delete(filter_key(args, :registrant_id))
+      }.to raise_error(Zoom::ParameterMissing)
+    end
+
+    it 'returns a status code of 204' do
+      expect(zc.webinar_registrant_delete(args)).to eq(204)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the webinar registrant delete action:

https://developers.zoom.us/docs/api/rest/reference/zoom-api/methods/#operation/deleteWebinarRegistrant