### PR TITLE
Add a past_webinars_participants action

### DIFF
--- a/lib/zoom/actions/webinar.rb
+++ b/lib/zoom/actions/webinar.rb
@@ -91,6 +91,9 @@ module Zoom
 
       get 'past_webinars_absentees', '/past_webinars/:webinar_uuid/absentees',
         permit: %i[occurrence_id page_size next_page_token]
+
+      get 'past_webinars_participants', '/past_webinars/:webinar_id/participants',
+        permit: %i[page_size next_page_token]
     end
   end
 end

--- a/spec/fixtures/webinar/past_webinars_participants.json
+++ b/spec/fixtures/webinar/past_webinars_participants.json
@@ -1,0 +1,20 @@
+{
+  "next_page_token": "Tva2CuIdTgsv8wAnhyAdU3m06Y2HuLQtlh3",
+  "page_count": 1,
+  "page_size": 30,
+  "participants": [
+    {
+      "id": "30R7kT7bTIKSNUFEuH_Qlg",
+      "name": "Jill Chill",
+      "user_id": "ABCDEF123456",
+      "registrant_id": "_f08HhPJS82MIVLuuFaJPg",
+      "user_email": "jchill@example.com",
+      "join_time": "2019-02-01T12:34:12.660Z",
+      "leave_time": "2019-02-01T12:54:12.660Z",
+      "duration": 20,
+      "failover": false,
+      "status": "in_meeting"
+    }
+  ],
+  "total_records": 1
+}

--- a/spec/lib/zoom/actions/webinar/past_webinar_participants_spec.rb
+++ b/spec/lib/zoom/actions/webinar/past_webinar_participants_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe Zoom::Actions::Webinar do
+  let(:zc) { zoom_client }
+  let(:args) { { webinar_id: '123456789' } }
+
+  describe '#past_webinars_participants' do
+    context 'with a valid response' do
+      before :each do
+        stub_request(
+          :get,
+          zoom_url("/past_webinars/#{args[:webinar_id]}/participants")
+        ).to_return(status: 200,
+                    body: json_response('webinar', 'past_webinars_participants'),
+                    headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it "requires a 'webinar_id' argument" do
+        expect { zc.past_webinars_participants(filter_key(args, :webinar_id)) }.to raise_error(Zoom::ParameterMissing, [:webinar_id].to_s)
+      end
+
+      it 'returns a webinar instance with participants as an array' do
+        expect(zc.past_webinars_participants(args)['participants']).to be_kind_of(Array)
+      end
+    end
+
+    context 'with a 4xx response' do
+      before :each do
+        stub_request(
+          :get,
+          zoom_url("/past_webinars/#{args[:webinar_id]}/participants")
+        ).to_return(status: 404,
+                    body: json_response('error', 'validation'),
+                    headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'raises Zoom::Error exception' do
+        expect { zc.past_webinars_participants(args) }.to raise_error(Zoom::Error)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the past webinar participants action:

https://developers.zoom.us/docs/api/rest/reference/zoom-api/methods/#operation/listWebinarParticipants