### PR TITLE
fix user_status_update endpoint

### DIFF
--- a/lib/zoom/actions/user.rb
+++ b/lib/zoom/actions/user.rb
@@ -67,8 +67,8 @@ module Zoom
       patch 'user_email_update', '/users/:id/email',
         permit: :email
 
-      patch 'user_status_update', '/users/:id/status',
-        permit: :status
+      put 'user_status_update', '/users/:id/status',
+        permit: :action
 
       get 'user_zak', '/users/me/zak'
     end


### PR DESCRIPTION
Originally I was not able to use this endpoint successfully. According to the [Zoom API docs here](https://developers.zoom.us/docs/api/rest/reference/user/methods/#operation/userStatus), this endpoint requires an `action` key to activate/deactivate users.